### PR TITLE
Create pyproject.toml with poetry contents

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name="ur"
+version="0.1.0"
+description="UR Implementation in Python -- ported from the C++ Reference Implementation by Blockchain Commons"
+license="BSD-2-Clause Plus Patent License"
+authors= ["Ken Carpenter <ken@foundationdevices.com>"]
+
+[tool.poetry.urls]
+repository = "https://github.com/Foundation-Devices/foundation-ur-py"
+
+[tool.poetry.dependencies]
+python = "^3.0"


### PR DESCRIPTION
This PR fixes Poetry-related issues: Krux cannot use **ur** in `[tool.poetry.dependencies]` with `develop=true`. Otherwise, `poetry install` or `poetry lock` fails with `Unable to create package with no name`.
